### PR TITLE
Improve handleEmergency

### DIFF
--- a/src/app/payment/[orderId]/page.tsx
+++ b/src/app/payment/[orderId]/page.tsx
@@ -123,6 +123,7 @@ export default function Page() {
       try {
         const _response = await axios.post(url, event)
         setCardStatus(LNURLWStatus.DONE)
+        // TODO: use nostr tools to card payments
         const events: Set<NDKEvent> = await ndk.fetchEvents({
           kinds: [1112 as NDKKind],
           authors: [process.env.NEXT_PUBLIC_LEDGER_PUBKEY!],

--- a/src/app/payment/[orderId]/page.tsx
+++ b/src/app/payment/[orderId]/page.tsx
@@ -59,6 +59,7 @@ export default function Page() {
     isPrinted,
     currentInvoice: invoice,
     emergency,
+    isCheckEmergencyEvent,
     handleEmergency,
     setIsPrinted,
     setIsPaid,
@@ -307,7 +308,44 @@ export default function Page() {
         isOpen={cardStatus === LNURLWStatus.ERROR}
       />
 
-      {isPaid ? (
+      {isCheckEmergencyEvent ? (
+        <>
+          <Container size="small">
+            <Divider y={24} />
+            <Flex
+              direction="column"
+              justify="center"
+              align="center"
+              gap={8}
+              flex={1}
+            >
+              <Heading>Event not found</Heading>
+              <Text>Try check envent again or create new invoice</Text>
+            </Flex>
+            <Divider y={24} />
+          </Container>
+
+          <Flex>
+            <Container size="small">
+              <Divider y={16} />
+              <Flex gap={8} direction="column">
+                <Flex gap={8}>
+                  <Button variant="bezeledGray" onClick={() => handleBack()}>
+                    Back
+                  </Button>
+                  <Button
+                    variant="bezeledGray"
+                    onClick={() => handleEmergency()}
+                  >
+                    Check event
+                  </Button>
+                </Flex>
+              </Flex>
+              <Divider y={24} />
+            </Container>
+          </Flex>
+        </>
+      ) : isPaid ? (
         <>
           <Confetti />
           <Container size="small">
@@ -382,7 +420,7 @@ export default function Page() {
             <Container size="small">
               <Divider y={16} />
               <Flex gap={8} direction="column">
-                <Flex>
+                <Flex gap={8}>
                   {isAvailable && permission === 'prompt' && (
                     <Button variant="bezeledGray" onClick={() => startRead()}>
                       Solicitar NFC
@@ -392,15 +430,14 @@ export default function Page() {
                   <Button variant="bezeledGray" onClick={() => handleBack()}>
                     Cancelar
                   </Button>
-                  {/* <Button
-                    variant="borderless"
+                  <Button
+                    variant="bezeledGray"
                     onClick={() => {
                       handleEmergency()
-                      handleBack()
                     }}
                   >
-                    Force Emergency Print
-                  </Button> */}
+                    Check event
+                  </Button>
                 </Flex>
               </Flex>
               <Divider y={24} />

--- a/src/context/Nostr.tsx
+++ b/src/context/Nostr.tsx
@@ -31,6 +31,7 @@ export interface INostrContext {
   localPrivateKey?: string
   relays?: string[]
   ndk: NDK
+  filter?: string
   getBalance: (pubkey: string) => Promise<number>
   generateZapEvent?: (amountMillisats: number, postEventId?: string) => NDKEvent
   subscribeZap?: (eventId: string) => NDKSubscription
@@ -78,6 +79,7 @@ export const NostrProvider = ({ children }: INostrProviderProps) => {
   // const [privateKey, setPrivateKey] = useState<string>()
   const [privateKey] = useLocalStorage('nostrPrivateKey', generatePrivateKey())
   const [publicKey, setPublicKey] = useState<string>()
+  const [filter, setFilter] = useState<string>()
 
   /** Functions */
   const generateZapEvent = useCallback(
@@ -128,6 +130,16 @@ export const NostrProvider = ({ children }: INostrProviderProps) => {
   const subscribeZap = (eventId: string): NDKSubscription => {
     console.info(`Listening for zap (${eventId})...`)
     console.info(`Recipient pubkey: ${zapEmitterPubKey}`)
+
+    setFilter(
+      JSON.stringify({
+        kinds: [9735],
+        authors: [zapEmitterPubKey!],
+        '#e': [eventId],
+        since: 1693157776
+      })
+    )
+
     const sub = ndk.subscribe(
       [
         {
@@ -184,6 +196,7 @@ export const NostrProvider = ({ children }: INostrProviderProps) => {
         localPrivateKey: privateKey,
         relays,
         ndk,
+        filter,
         getBalance,
         generateZapEvent,
         subscribeZap,

--- a/src/context/Nostr.tsx
+++ b/src/context/Nostr.tsx
@@ -140,6 +140,7 @@ export const NostrProvider = ({ children }: INostrProviderProps) => {
       })
     )
 
+    // TODO: subscribe with nostr-tools
     const sub = ndk.subscribe(
       [
         {


### PR DESCRIPTION
I fixed and improved the `handleEmergency` function to find event through the API if subscription to relay fails.

I fetch to [LaWallet endpoint to find an event](https://backend.lawallet.io/wallet-provider/api/fetch) with the same filter used for subscription to search a zapReceipt of LaPOS payment receipt.

# CHANGELOG
- Return filter used to use to subscribe to relay 
- Improve `handleEmergency` function to fetch API. [File](
- Add screen if the event is not found in first request, allowing try check again or back to LaPOS menu.

# TODOs
- Fix subscriptions (for invoice or LaCard payments) to use nostr-tools
