### PR TITLE
fix: LUD-21 verify stops polling after first successful order

### DIFF
--- a/src/context/Order.tsx
+++ b/src/context/Order.tsx
@@ -173,7 +173,8 @@ export const OrderProvider = ({ children }: IOrderProviderProps) => {
       isPaid,
       lud06: lud06!,
       isPrinted: isPrinted,
-      items: products
+      items: products,
+      lud21Verify: lud21
     }
 
     paymentsCache[payment.id] = payment
@@ -189,6 +190,7 @@ export const OrderProvider = ({ children }: IOrderProviderProps) => {
     localPrivateKey,
     isPaid,
     lud06,
+    lud21,
     isPrinted,
     paymentsCache,
     setPaymentsCache
@@ -209,6 +211,7 @@ export const OrderProvider = ({ children }: IOrderProviderProps) => {
       setOrderEvent(order.event)
       setLUD06(order.lud06)
       setOrderId(order.id)
+      if (order.lud21Verify) setLUD21(order.lud21Verify)
 
       console.dir(order)
       return true
@@ -339,6 +342,7 @@ export const OrderProvider = ({ children }: IOrderProviderProps) => {
     setError(undefined)
     setCheckEmergencyEvent(false)
     setSubZap(undefined)
+    setLUD21(undefined)
   }, [])
 
   /** useEffects */

--- a/src/hooks/useVerifyLud21.ts
+++ b/src/hooks/useVerifyLud21.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 
 interface IUseVerifyLud21 {
   lud21VerifyUrl: string
@@ -12,21 +12,57 @@ export const useVerifyLud21 = ({
   delay = 2000
 }: IUseVerifyLud21): boolean => {
   const [settled, setSettled] = useState(false)
+  const prevUrlRef = useRef(lud21VerifyUrl)
 
+  // Reset settled state when verify URL changes (new order)
+  useEffect(() => {
+    if (lud21VerifyUrl !== prevUrlRef.current) {
+      setSettled(false)
+      prevUrlRef.current = lud21VerifyUrl
+    }
+  }, [lud21VerifyUrl])
+
+  // Use recursive setTimeout instead of setInterval to prevent
+  // concurrent requests when fetch takes longer than the delay
   useEffect(() => {
     if (!enabled || !lud21VerifyUrl || settled) return
 
-    let interval = setInterval(async () => {
-      try {
-        const response = await fetch(lud21VerifyUrl)
-        const data = await response.json()
-        data.settled && setSettled(true)
-      } catch (error) {
-        console.error('Error verifying LUD21:', error)
-      }
-    }, delay)
+    let cancelled = false
+    let timeoutId: ReturnType<typeof setTimeout>
 
-    return () => clearInterval(interval)
+    const check = async () => {
+      try {
+        const controller = new AbortController()
+        const fetchTimeout = setTimeout(() => controller.abort(), delay * 2)
+
+        const response = await fetch(lud21VerifyUrl, {
+          signal: controller.signal
+        })
+        clearTimeout(fetchTimeout)
+
+        const data = await response.json()
+        if (data.settled) {
+          setSettled(true)
+          return
+        }
+      } catch (error) {
+        if ((error as Error).name !== 'AbortError') {
+          console.error('Error verifying LUD21:', error)
+        }
+      }
+
+      if (!cancelled) {
+        timeoutId = setTimeout(check, delay)
+      }
+    }
+
+    // Start first check
+    check()
+
+    return () => {
+      cancelled = true
+      clearTimeout(timeoutId)
+    }
   }, [enabled, delay, lud21VerifyUrl, settled])
 
   return settled

--- a/src/types/order.ts
+++ b/src/types/order.ts
@@ -21,6 +21,7 @@ export interface IPayment {
   lud06: LNURLResponse
   isPaid: boolean
   isPrinted: boolean
+  lud21Verify?: string
 }
 
 export interface IPaymentCache {


### PR DESCRIPTION
## Problem

LUD-21 payment verification stops working after the first successful order. Subsequent orders appear "stuck" and require manually pressing the Check button.

### Root causes

1. **`settled` state never resets between orders** — The `useVerifyLud21` hook has internal `settled` state that stays `true` after the first payment is detected. When a new order starts with a new verify URL, the hook exits immediately because `settled` is still `true`.

2. **`setInterval` with async callback causes request accumulation** — If the LUD-21 endpoint takes >2s to respond, multiple concurrent requests stack up. Server rate limiting or timeouts can then cause all subsequent checks to fail silently.

3. **`lud21` verify URL not persisted in payment cache** — On page reload at `/payment/[orderId]`, the order loads from cache but `lud21` stays `undefined`, so polling never starts.

4. **`lud21` not cleared between orders** — `clear()` did not reset `lud21` state.

### Fixes

- **Reset `settled` when `lud21VerifyUrl` changes** — New order = fresh polling state
- **Replace `setInterval` with recursive `setTimeout`** — Waits for each request to complete before scheduling the next, preventing accumulation
- **Add `AbortController` timeout** — Prevents hung fetch requests from blocking the polling loop
- **Persist `lud21Verify` in `IPayment` cache** — Survives page reloads
- **Restore `lud21` in `loadOrder()`** — Cache recovery works correctly
- **Clear `lud21` in `clear()`** — Clean state between orders