### PR TITLE
fix: relay subscription loss causes missed zap payments

### DIFF
--- a/src/context/Nostr.tsx
+++ b/src/context/Nostr.tsx
@@ -125,11 +125,12 @@ export const NostrProvider = ({ children }: INostrProviderProps) => {
     console.info(`Listening for zap (${eventId})...`)
     console.info(`Recipient pubkey: ${zapEmitterPubKey}`)
 
+    // Use a 30-second buffer to handle clock drift between client and relay
     const zapFilters = {
       kinds: [9735],
       authors: [zapEmitterPubKey!],
       '#e': [eventId],
-      since: Math.floor(new Date().getTime() / 1000)
+      since: Math.floor(new Date().getTime() / 1000) - 30
     }
 
     setFilter(JSON.stringify(zapFilters))

--- a/src/context/Order.tsx
+++ b/src/context/Order.tsx
@@ -6,6 +6,7 @@ import {
   useCallback,
   useContext,
   useEffect,
+  useRef,
   useState
 } from 'react'
 
@@ -307,16 +308,19 @@ export const OrderProvider = ({ children }: IOrderProviderProps) => {
     }
   }
 
-  // Handle new incoming zap
-  const onZap = (event: NDKEvent) => {
+  // Handle new incoming zap — use ref to avoid stale closure in subscription
+  const onZapRef = useRef<(event: NDKEvent) => void>()
+  onZapRef.current = (event: NDKEvent) => {
     console.info('onZap in Order.tsx')
     console.dir(event)
     if (event.pubkey !== zapEmitterPubKey) {
-      throw new Error('Invalid Recipient Pubkey')
+      console.warn('Invalid Recipient Pubkey, ignoring event')
+      return
     }
 
     if (!validateEvent(event)) {
-      throw new Error('Invalid event')
+      console.warn('Invalid event, ignoring')
+      return
     }
 
     const paidInvoice = event.tags.find(tag => tag[0] === 'bolt11')?.[1]
@@ -325,6 +329,10 @@ export const OrderProvider = ({ children }: IOrderProviderProps) => {
     handlePaymentReceived(event)
     console.info('Amount paid : ' + decodedPaidInvoice.millisatoshis)
   }
+
+  const onZap = useCallback((event: NDKEvent) => {
+    onZapRef.current?.(event)
+  }, [])
 
   const clear = useCallback(() => {
     setOrderId(undefined)
@@ -404,10 +412,16 @@ export const OrderProvider = ({ children }: IOrderProviderProps) => {
       })
   }, [amount, orderId, zapEmitterPubKey, requestZapInvoice])
 
+  // Re-subscribe on relay reconnect
   const handleResubscription = useCallback(
     (relay: NDKRelay) => {
       if (relay && subZap && filter) {
-        relay.subscribe(subZap, [JSON.parse(filter)])
+        console.info(`Relay reconnected: ${relay.url}, re-subscribing...`)
+        try {
+          relay.subscribe(subZap, [JSON.parse(filter)])
+        } catch (e) {
+          console.error('Failed to resubscribe on relay reconnect:', e)
+        }
       }
     },
     [subZap, filter]
@@ -420,6 +434,24 @@ export const OrderProvider = ({ children }: IOrderProviderProps) => {
       ndk.pool.off('relay:connect', handleResubscription)
     }
   }, [handleResubscription, ndk.pool])
+
+  // Periodic relay health check — if subscription is active but all relays
+  // disconnected, attempt to reconnect NDK
+  useEffect(() => {
+    if (!subZap || isPaid) return
+
+    const healthCheck = setInterval(() => {
+      const connectedRelays = Array.from(ndk.pool.relays.values()).filter(
+        r => r.connectivity.isAvailable()
+      )
+      if (connectedRelays.length === 0) {
+        console.warn('No connected relays detected, attempting reconnect...')
+        void ndk.connect()
+      }
+    }, 10000) // Check every 10 seconds
+
+    return () => clearInterval(healthCheck)
+  }, [subZap, isPaid, ndk])
 
   useEffect(() => {
     if (lud21Paid) {


### PR DESCRIPTION
## Problem

The Nostr relay subscription for detecting zap payments (NIP-57) silently dies, causing payments to appear undetected. Users have to manually press the "Check event" button to verify payment.

### Root causes

1. **Stale closure in `onZap` handler** — `onZap` is defined as a regular function that captures `zapEmitterPubKey` and `handlePaymentReceived` (which depends on `amount`) at subscription time. If these values change after `subZap.on("event", onZap)` is called, the handler uses stale values and may fail silently or throw.

2. **`onZap` throws on invalid events** — `throw new Error("Invalid Recipient Pubkey")` crashes the event handler instead of gracefully skipping the event. This can kill the entire subscription listener.

3. **No clock drift buffer** — The zap subscription filter uses `since: Math.floor(Date.now() / 1000)` with zero buffer. Any clock drift between the client and relay means recent events are missed.

4. **No relay health monitoring** — If all relays disconnect (mobile network changes, sleep/wake, etc.), there is no mechanism to detect this and reconnect. The `relay:connect` handler only fires on reconnection, but nothing triggers the reconnection itself.

### Fixes

- **Use `useRef` for `onZap` handler** — The stable callback wrapper delegates to a ref that always has the latest closure values
- **Replace `throw` with `console.warn` + `return`** — Invalid events are logged and skipped instead of crashing the handler
- **Add 30-second buffer to `since` filter** — Accounts for clock drift between client and relay
- **Add periodic relay health check** — Every 10 seconds, checks if any relays are connected. If none, triggers `ndk.connect()` to re-establish connections
- **Improved logging** — Relay reconnection and resubscription events are logged for debugging