### PR TITLE
fix: add server-side LNURL proxy to bypass CORS on LUD-16 resolution

### DIFF
--- a/src/app/api/lnurl-resolve/route.ts
+++ b/src/app/api/lnurl-resolve/route.ts
@@ -1,0 +1,94 @@
+import { NextRequest, NextResponse } from 'next/server'
+
+/**
+ * Server-side LNURL/LUD-16 resolver to bypass CORS restrictions.
+ *
+ * The browser cannot directly fetch `/.well-known/lnurlp/<user>` from
+ * arbitrary domains due to CORS. This API route performs the request
+ * server-side where CORS does not apply, then returns the response
+ * to the client.
+ *
+ * Usage: GET /api/lnurl-resolve?address=user@domain.com
+ *   or:  GET /api/lnurl-resolve?url=https://domain.com/.well-known/lnurlp/user
+ */
+export async function GET(request: NextRequest) {
+  const { searchParams } = new URL(request.url)
+  const address = searchParams.get('address')
+  const rawUrl = searchParams.get('url')
+
+  let resolveUrl: string
+
+  if (address) {
+    // Parse Lightning Address (LUD-16): user@domain → https://domain/.well-known/lnurlp/user
+    const parts = address.split('@')
+    if (parts.length !== 2) {
+      return NextResponse.json(
+        { status: 'ERROR', reason: 'Invalid Lightning Address format' },
+        { status: 400 }
+      )
+    }
+    const [user, domain] = parts
+    if (!user || !domain) {
+      return NextResponse.json(
+        { status: 'ERROR', reason: 'Invalid Lightning Address format' },
+        { status: 400 }
+      )
+    }
+    resolveUrl = `https://${domain}/.well-known/lnurlp/${user}`
+  } else if (rawUrl) {
+    // Direct LNURL resolve URL
+    try {
+      const parsed = new URL(rawUrl)
+      if (!['http:', 'https:'].includes(parsed.protocol)) {
+        throw new Error('Invalid protocol')
+      }
+      resolveUrl = rawUrl
+    } catch {
+      return NextResponse.json(
+        { status: 'ERROR', reason: 'Invalid URL' },
+        { status: 400 }
+      )
+    }
+  } else {
+    return NextResponse.json(
+      { status: 'ERROR', reason: 'Missing "address" or "url" parameter' },
+      { status: 400 }
+    )
+  }
+
+  try {
+    const controller = new AbortController()
+    const timeout = setTimeout(() => controller.abort(), 10000)
+
+    const response = await fetch(resolveUrl, {
+      signal: controller.signal,
+      headers: {
+        Accept: 'application/json'
+      }
+    })
+    clearTimeout(timeout)
+
+    if (!response.ok) {
+      return NextResponse.json(
+        {
+          status: 'ERROR',
+          reason: `Upstream returned ${response.status}: ${response.statusText}`
+        },
+        { status: 502 }
+      )
+    }
+
+    const data = await response.json()
+    return NextResponse.json(data)
+  } catch (error) {
+    const message =
+      (error as Error).name === 'AbortError'
+        ? 'Request timed out'
+        : (error as Error).message || 'Unknown error'
+
+    return NextResponse.json(
+      { status: 'ERROR', reason: `Failed to resolve LNURL: ${message}` },
+      { status: 502 }
+    )
+  }
+}

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -135,14 +135,30 @@ export function isValidUrl(urlString: string): boolean {
 }
 
 export async function fetchLNURL(lnurl: string): Promise<LNURLResponse> {
-  console.info('fetchLNURL')
-  console.info(lnurl)
-  console.info('requestPayServiceParams')
-  return (
-    await requestPayServiceParams({
+  console.info('fetchLNURL:', lnurl)
+
+  // First try direct resolution via lnurl-pay library
+  try {
+    const result = await requestPayServiceParams({
       lnUrlOrAddress: lnurl
     })
-  ).rawData as unknown as LNURLResponse
+    return result.rawData as unknown as LNURLResponse
+  } catch (directError) {
+    console.warn('Direct LNURL fetch failed (likely CORS), trying server proxy:', directError)
+  }
+
+  // Fallback: use server-side proxy to bypass CORS
+  const params = lnurl.includes('@')
+    ? `address=${encodeURIComponent(lnurl)}`
+    : `url=${encodeURIComponent(lnurl)}`
+  const response = await fetch(`/api/lnurl-resolve?${params}`)
+  const data = await response.json()
+
+  if (data.status === 'ERROR') {
+    throw new Error(data.reason || 'Failed to resolve LNURL via proxy')
+  }
+
+  return data as LNURLResponse
 }
 
 interface InternalTransactionEventParams {


### PR DESCRIPTION
## Problem

When resolving Lightning Addresses from external domains (e.g., `user@walletofsatoshi.com`), the browser fetch to `https://walletofsatoshi.com/.well-known/lnurlp/user` is blocked by CORS. The `lnurl-pay` library makes this request client-side, and many Lightning service providers do not set `Access-Control-Allow-Origin` headers.

### Fix

Add a Next.js API route (`/api/lnurl-resolve`) that performs the LNURL/LUD-16 resolution server-side, where CORS does not apply.

**API Usage:**
- `GET /api/lnurl-resolve?address=user@domain.com` — resolves Lightning Address
- `GET /api/lnurl-resolve?url=https://domain.com/.well-known/lnurlp/user` — resolves raw URL

**Features:**
- 10-second timeout with AbortController
- Input validation (address format, URL protocol)
- Proper error responses (400 for bad input, 502 for upstream failures)

**Client-side change:**
`fetchLNURL()` in `utils.ts` now tries the direct `lnurl-pay` library first. If it fails (CORS), it automatically falls back to the server-side proxy. This means domains that already support CORS continue working without an extra hop.