### PR TITLE
fix: QR code shows wrong invoice due to race condition

### DIFF
--- a/src/context/Order.tsx
+++ b/src/context/Order.tsx
@@ -6,6 +6,7 @@ import {
   useCallback,
   useContext,
   useEffect,
+  useRef,
   useState
 } from 'react'
 
@@ -339,6 +340,7 @@ export const OrderProvider = ({ children }: IOrderProviderProps) => {
     setError(undefined)
     setCheckEmergencyEvent(false)
     setSubZap(undefined)
+    invoiceRequestIdRef.current++  // Invalidate any in-flight invoice requests
   }, [])
 
   /** useEffects */
@@ -388,21 +390,34 @@ export const OrderProvider = ({ children }: IOrderProviderProps) => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [subZap])
 
-  // On orderId change
+  // On orderId change — request invoice
+  // Use a ref to track the current request and prevent stale responses
+  // from overwriting the current invoice (race condition)
+  const invoiceRequestIdRef = useRef(0)
   useEffect(() => {
     if (!orderId || !zapEmitterPubKey || amount === 0) {
       return
     }
 
+    // Increment request ID to invalidate any in-flight requests
+    const requestId = ++invoiceRequestIdRef.current
+
     requestZapInvoice!(amount * 1000, orderId)
       .then(_invoice => {
+        // Only update state if this is still the current request
+        if (requestId !== invoiceRequestIdRef.current) {
+          console.warn('Ignoring stale invoice response (superseded by newer request)')
+          return
+        }
         setLUD21(_invoice.verify)
         setCurrentInvoice!(_invoice.pr)
       })
       .catch((e: Error) => {
+        if (requestId !== invoiceRequestIdRef.current) return
         setError(`Couldn't generate invoice. ${e.cause}`)
       })
-  }, [amount, orderId, zapEmitterPubKey, requestZapInvoice])
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [amount, orderId, zapEmitterPubKey])
 
   const handleResubscription = useCallback(
     (relay: NDKRelay) => {


### PR DESCRIPTION
## Problem

The QR code sometimes displays an invoice that does not match the current payment. The user scans/pays one invoice, but the system is verifying a different one — causing the payment to appear undetected.

### Root cause

The `useEffect` that calls `requestZapInvoice` includes `requestZapInvoice` in its dependency array. Since `requestZapInvoice` is a `useCallback` that depends on `generateZapEvent` → which depends on `zapEmitterPubKey`, `privateKey`, `publicKey` — it gets recreated frequently.

Each recreation triggers the effect, which calls `requestZapInvoice` again and generates a **new invoice**. The race condition:

1. Effect fires → requests invoice A → sets `currentInvoice = A` (QR shows A)
2. `requestZapInvoice` callback reference changes (dep change)
3. Effect fires again → requests invoice B
4. Invoice A response arrives → sets `currentInvoice = A` (but B was requested)
5. Invoice B response arrives → sets `currentInvoice = B` (QR changes to B)
6. Meanwhile, NFC read already sent invoice A to the card
7. Zap subscription is watching for the order event, but the paid invoice was A, and LUD-21 verify URL points to B

The result: QR flickers between invoices, and payment detection fails because the verify URL and invoice are out of sync.

### Fix

- **Track requests with incrementing ID ref** — Each `requestZapInvoice` call gets a unique ID. When the response arrives, it checks if it is still the "current" request. Stale responses are discarded.
- **Remove `requestZapInvoice` from deps** — It is a callback that changes on render cycles. The meaningful deps are `amount`, `orderId`, and `zapEmitterPubKey`.
- **Invalidate on `clear()`** — Incrementing the ref on clear ensures any in-flight request from a previous order is ignored.