### PR TITLE
Actualizar menús del evento y endurecer verificación de pago LUD21

### DIFF
--- a/src/constants/menus/barra.json
+++ b/src/constants/menus/barra.json
@@ -6,37 +6,87 @@
     "description": "",
     "price": {
       "value": 2100,
-      "currency": "SAT"
+      "currency": "ARS"
     }
   },
   {
     "id": 2,
     "category_id": 10,
-    "name": "Seven",
+    "name": "Coca Zero",
     "description": "",
     "price": {
       "value": 2100,
-      "currency": "SAT"
+      "currency": "ARS"
     }
   },
   {
     "id": 3,
     "category_id": 10,
-    "name": "Agua",
+    "name": "7Up",
     "description": "",
     "price": {
-      "value": 1200,
-      "currency": "SAT"
+      "value": 2100,
+      "currency": "ARS"
     }
   },
   {
     "id": 4,
-    "category_id": 9,
-    "name": "Cerveza",
+    "category_id": 10,
+    "name": "Agua Mineral",
     "description": "",
     "price": {
-      "value": 3100,
-      "currency": "SAT"
+      "value": 2100,
+      "currency": "ARS"
+    }
+  },
+  {
+    "id": 5,
+    "category_id": 9,
+    "name": "Cerveza Andes Rubia 473ml",
+    "description": "",
+    "price": {
+      "value": 4200,
+      "currency": "ARS"
+    }
+  },
+  {
+    "id": 6,
+    "category_id": 9,
+    "name": "Fuck KYC (Cuba Libre)",
+    "description": "",
+    "price": {
+      "value": 7300,
+      "currency": "ARS"
+    }
+  },
+  {
+    "id": 7,
+    "category_id": 9,
+    "name": "Bitcoinari (Campari con naranja)",
+    "description": "",
+    "price": {
+      "value": 7300,
+      "currency": "ARS"
+    }
+  },
+  {
+    "id": 8,
+    "category_id": 9,
+    "name": "Fernostr (Fernet con Coca)",
+    "description": "",
+    "price": {
+      "value": 7300,
+      "currency": "ARS"
+    }
+  },
+  {
+    "id": 9,
+    "category_id": 9,
+    "name": "Lightning Tonic (Gin Tonic)",
+    "description": "",
+    "price": {
+      "value": 7300,
+      "currency": "ARS"
     }
   }
 ]

--- a/src/constants/menus/comida.json
+++ b/src/constants/menus/comida.json
@@ -1,12 +1,32 @@
 [
   {
     "id": 1,
-    "category_id": 4,
-    "name": "Shawarma",
+    "category_id": 8,
+    "name": "Porción de Pizza",
     "description": "",
     "price": {
-      "value": 14400,
-      "currency": "SAT"
+      "value": 3000,
+      "currency": "ARS"
+    }
+  },
+  {
+    "id": 2,
+    "category_id": 8,
+    "name": "2 x Porciones",
+    "description": "",
+    "price": {
+      "value": 5500,
+      "currency": "ARS"
+    }
+  },
+  {
+    "id": 3,
+    "category_id": 8,
+    "name": "Pizza entera",
+    "description": "",
+    "price": {
+      "value": 21000,
+      "currency": "ARS"
     }
   }
 ]

--- a/src/constants/menus/merch.json
+++ b/src/constants/menus/merch.json
@@ -15,7 +15,7 @@
     "name": "Popsocket celular",
     "description": "",
     "price": {
-      "value": 2490,
+      "value": 1000,
       "currency": "ARS"
     }
   },
@@ -35,7 +35,7 @@
     "name": "Moneda BTC La Crypta",
     "description": "",
     "price": {
-      "value": 6900,
+      "value": 3500,
       "currency": "ARS"
     }
   },
@@ -55,7 +55,7 @@
     "name": "Vela aromática grande",
     "description": "",
     "price": {
-      "value": 16000,
+      "value": 21000,
       "currency": "ARS"
     }
   },
@@ -65,7 +65,7 @@
     "name": "Vaso plástico con tapa",
     "description": "",
     "price": {
-      "value": 6900,
+      "value": 1500,
       "currency": "ARS"
     }
   },
@@ -75,7 +75,7 @@
     "name": "Manta Polar",
     "description": "",
     "price": {
-      "value": 17900,
+      "value": 26000,
       "currency": "ARS"
     }
   },
@@ -85,7 +85,17 @@
     "name": "Remera",
     "description": "",
     "price": {
-      "value": 27900,
+      "value": 33000,
+      "currency": "ARS"
+    }
+  },
+  {
+    "id": 26,
+    "category_id": 16,
+    "name": "Remera Premium",
+    "description": "",
+    "price": {
+      "value": 57000,
       "currency": "ARS"
     }
   },
@@ -112,31 +122,31 @@
   {
     "id": 12,
     "category_id": 16,
-    "name": "Gorras",
+    "name": "Gorra con sol bordado",
     "description": "",
     "price": {
-      "value": 21990,
+      "value": 32000,
       "currency": "ARS"
     }
   },
   {
-    "id": 13,
-    "category_id": 12,
-    "name": "Trezor Safe 5",
+    "id": 27,
+    "category_id": 16,
+    "name": "Gorra argentina artesanal",
     "description": "",
     "price": {
-      "value": 374900,
+      "value": 28000,
       "currency": "ARS"
     }
   },
   {
-    "id": 14,
-    "category_id": 12,
-    "name": "Jade",
+    "id": 28,
+    "category_id": 16,
+    "name": "Beanie",
     "description": "",
     "price": {
-      "value": 100,
-      "currency": "USD"
+      "value": 19000,
+      "currency": "ARS"
     }
   },
   {
@@ -145,7 +155,7 @@
     "name": "Profecía Bitcoin",
     "description": "",
     "price": {
-      "value": 25000,
+      "value": 30000,
       "currency": "ARS"
     }
   },
@@ -180,32 +190,12 @@
     }
   },
   {
-    "id": 19,
-    "category_id": 17,
-    "name": "El patrón Fiat",
-    "description": "",
-    "price": {
-      "value": 33000,
-      "currency": "ARS"
-    }
-  },
-  {
     "id": 20,
     "category_id": 17,
     "name": "El Patrón Bitcoin",
     "description": "",
     "price": {
       "value": 21000,
-      "currency": "ARS"
-    }
-  },
-  {
-    "id": 21,
-    "category_id": 17,
-    "name": "Principios de Economía",
-    "description": "",
-    "price": {
-      "value": 44000,
       "currency": "ARS"
     }
   },
@@ -226,6 +216,26 @@
     "description": "",
     "price": {
       "value": 35,
+      "currency": "USD"
+    }
+  },
+  {
+    "id": 24,
+    "category_id": 15,
+    "name": "Portavasos legacy",
+    "description": "",
+    "price": {
+      "value": 500,
+      "currency": "ARS"
+    }
+  },
+  {
+    "id": 25,
+    "category_id": 15,
+    "name": "POS",
+    "description": "",
+    "price": {
+      "value": 210,
       "currency": "USD"
     }
   }

--- a/src/hooks/useVerifyLud21.ts
+++ b/src/hooks/useVerifyLud21.ts
@@ -12,24 +12,31 @@ export const useVerifyLud21 = ({
   delay = 2000
 }: IUseVerifyLud21): boolean => {
   const [settled, setSettled] = useState(false)
+  const settledRef = useRef(false)
   const prevUrlRef = useRef(lud21VerifyUrl)
 
-  // Reset settled when the verify URL changes (new invoice/order)
-  useEffect(() => {
-    if (prevUrlRef.current !== lud21VerifyUrl) {
-      prevUrlRef.current = lud21VerifyUrl
+  // Reset settled synchronously when the verify URL changes (new invoice/order)
+  if (prevUrlRef.current !== lud21VerifyUrl) {
+    prevUrlRef.current = lud21VerifyUrl
+    settledRef.current = false
+    if (settled) {
       setSettled(false)
     }
-  }, [lud21VerifyUrl])
+  }
 
   useEffect(() => {
-    if (!enabled || !lud21VerifyUrl || settled) return
+    if (!enabled || !lud21VerifyUrl || settledRef.current) return
 
     const interval = setInterval(async () => {
+      if (settledRef.current) {
+        clearInterval(interval)
+        return
+      }
       try {
         const response = await fetch(lud21VerifyUrl)
         const data = await response.json()
         if (data.settled) {
+          settledRef.current = true
           setSettled(true)
           clearInterval(interval)
         }


### PR DESCRIPTION
## Resumen

- **Menús del evento** (`barra`, `comida`, `merch`): precios y productos actualizados según lo definido para el evento.
- **Fix LUD21**: endurece la detección de pagos Lightning contra un flag `settled` viejo que se arrastraba a una nueva invoice/orden.

## Cambios en menús

**barra.json** — reescrito a ARS (antes en SAT):
- Sin alcohol: Coca, Coca Zero, 7Up, Agua Mineral — $2100 c/u
- Con alcohol: Cerveza Andes Rubia 473ml $4200; Fuck KYC, Bitcoinari, Fernostr, Lightning Tonic — $7300 c/u

**comida.json** — reemplaza Shawarma por pizzas:
- Porción $3000 · 2x Porciones $5500 · Pizza entera $21000 (ARS)

**merch.json**:
- Ajustes de precio: Popsocket $1000, Moneda BTC La Crypta $3500, Vela aromática grande $21000, Vaso plástico $1500, Manta Polar $26000, Remera $33000, Profecía Bitcoin $30000
- Altas: Remera Premium $57000, Portavasos legacy $500, POS USD 210, Gorra con sol bordado $32000, Gorra argentina artesanal $28000, Beanie $19000
- Bajas: hardware wallets (Trezor Safe 5, Jade), El patrón Fiat, Principios de Economía

## Fix LUD21 (useVerifyLud21.ts)

- Usa un settledRef para lecturas sincronas dentro del intervalo de polling.
- Resetea el flag de forma sincrona al cambiar la verify-URL, evitando que un settled previo se arrastre a una invoice nueva (falsos positivos / doble disparo).

## Para el reviewer

Conflicto esperado en barra.json: main recibio commits que dejaron la barra en SAT (fix openclaw meetup drink prices). Esta rama la reescribe a ARS. Ambos enfoques son incompatibles (SAT vs ARS, 4 vs 9 items). Hay que decidir conscientemente cual queda; esta PR asume que el menu en ARS es el final. comida y merch no fueron tocados en main, asi que entran limpios.

Generated with Claude Code