### PR TITLE
feat: bar tab system (cuenta por cliente)

### DIFF
--- a/src/app/[destination]/page.tsx
+++ b/src/app/[destination]/page.tsx
@@ -19,9 +19,9 @@ import { fetchLNURL, normalizeLNURL } from '@/lib/utils'
 // Components
 import { Flex, Heading, Text, Divider, Icon, Card } from '@/components/UI'
 import Container from '@/components/Layout/Container'
+import Top from '../layout/top'
 import {
   PantheonIcon,
-  GearIcon,
   InvoiceIcon,
   MenuIcon
 } from '@bitcoin-design/bitcoin-icons-react/filled'
@@ -41,6 +41,7 @@ function getMetadataIdentifier(metadata?: string): string | undefined {
 export default function Page() {
   const [isLoading, setIsLoading] = useState<boolean>(true)
   const [, setStoredDestination] = useLocalStorage('destination', '')
+  const [tabEnabled] = useLocalStorage<boolean>('tabEnabled', false)
 
   // Hooks
   const router = useRouter()
@@ -128,6 +129,7 @@ export default function Page() {
 
   return (
     <>
+      <Top />
       <Container size="small">
         <Divider y={24} />
         <Flex direction="column" gap={8} flex={1} justify="center">
@@ -244,42 +246,48 @@ export default function Page() {
                 </Flex>
               )}
 
-              <Flex gap={8}>
-                <Card>
-                  <Link href="/paydesk">
-                    <Icon>
-                      <PantheonIcon />
-                    </Icon>
-                    <Flex direction="column" gap={4}>
-                      <Heading as="h5">Cash Register</Heading>
-                      <Text size="small">
-                        Type the price and pay with your LN.
-                      </Text>
-                    </Flex>
-                  </Link>
-                </Card>
-                <Card color="secondary">
-                  <Link href="/settings">
-                    <Icon>
-                      <GearIcon />
-                    </Icon>
-                    <Flex direction="column" gap={4}>
-                      <Heading as="h5">Settings</Heading>
-                      <Text size="small">POS Configuration</Text>
-                    </Flex>
-                  </Link>
-                </Card>
-                <Card>
-                  <Link href="/orders">
-                    <Icon>
-                      <InvoiceIcon />
-                    </Icon>
-                    <Flex direction="column" gap={4}>
-                      <Heading as="h5">Ordenes</Heading>
-                      <Text size="small">Historial del POS.</Text>
-                    </Flex>
-                  </Link>
-                </Card>
+              <Flex direction="column" gap={8}>
+                <Flex gap={8}>
+                  <Card>
+                    <Link href="/paydesk">
+                      <Icon>
+                        <PantheonIcon />
+                      </Icon>
+                      <Flex direction="column" gap={4}>
+                        <Heading as="h5">Cash Register</Heading>
+                        <Text size="small">
+                          Type the price and pay with your LN.
+                        </Text>
+                      </Flex>
+                    </Link>
+                  </Card>
+                  <Card>
+                    <Link href="/orders">
+                      <Icon>
+                        <InvoiceIcon />
+                      </Icon>
+                      <Flex direction="column" gap={4}>
+                        <Heading as="h5">Ordenes</Heading>
+                        <Text size="small">Historial del POS.</Text>
+                      </Flex>
+                    </Link>
+                  </Card>
+                </Flex>
+                {tabEnabled && (
+                  <Flex gap={8}>
+                    <Card color="secondary">
+                      <Link href="/tab">
+                        <Icon>
+                          <InvoiceIcon />
+                        </Icon>
+                        <Flex direction="column" gap={4}>
+                          <Heading as="h5">Cerrar cuenta</Heading>
+                          <Text size="small">Cuentas abiertas (tab).</Text>
+                        </Flex>
+                      </Link>
+                    </Card>
+                  </Flex>
+                )}
               </Flex>
             </>
           )}

--- a/src/app/layout/top.tsx
+++ b/src/app/layout/top.tsx
@@ -7,7 +7,11 @@ export default function Top() {
   return (
     <Flex direction="row" justify="end" align="center">
       <div style={{ marginRight: '8px', marginTop: '8px' }}>
-        <Button onClick={() => router.push('/settings')}>
+        <Button
+          variant="bezeledGray"
+          size="small"
+          onClick={() => router.push('/settings')}
+        >
           <GearIcon />
         </Button>
       </div>

--- a/src/app/payment/[orderId]/page.tsx
+++ b/src/app/payment/[orderId]/page.tsx
@@ -17,6 +17,7 @@ import { useOrder } from '@/context/Order'
 import { useLN } from '@/context/LN'
 import { useCard } from '@/hooks/useCard'
 import { usePrint } from '@/hooks/usePrint'
+import { useTabs } from '@/hooks/useTabs'
 import useCurrencyConverter from '@/hooks/useCurrencyConverter'
 import { LaWalletContext } from '@/context/LaWalletContext'
 
@@ -33,13 +34,17 @@ import {
   QRCode,
   Confetti,
   Icon,
-  Alert
+  Alert,
+  Sheet
 } from '@/components/UI'
 import Container from '@/components/Layout/Container'
+import Input from '@/components/UI/Input'
 import { Loader } from '@/components/Loader/Loader'
 import { CheckIcon } from '@bitcoin-design/bitcoin-icons-react/filled'
 import theme from '@/styles/theme'
 import { PrintOrder } from '@/types/print'
+import { ProductQtyData } from '@/types/product'
+import { ITab } from '@/types/tab'
 import { useBitcoinBlock } from '@/context/BitcoinBlock'
 
 export default function Page() {
@@ -48,6 +53,8 @@ export default function Page() {
   const { orderId: orderIdFromUrl } = useParams()
   const query = useSearchParams()
   const [lastCheckoutBack] = useLocalStorage('lastCheckoutBack', '')
+  const [tabEnabled] = useLocalStorage<boolean>('tabEnabled', false)
+  const [tipEnabled] = useLocalStorage<boolean>('tipEnabled', false)
   const { convertCurrency, pricesData } = useCurrencyConverter()
   const { zapEmitterPubKey } = useLN()
   const { lastBlockNumber } = useBitcoinBlock()
@@ -64,15 +71,26 @@ export default function Page() {
     setCheckEmergencyEvent,
     setIsPrinted,
     loadOrder,
-    clear
+    clear,
+    setAmount,
+    setProducts,
+    setOrderEvent,
+    generateOrderEvent,
+    publishOrderInBackground
   } = useOrder()
   const { isAvailable, permission, status: scanStatus, scan, stop } = useCard()
   const { print } = usePrint()
+  const { tabs, addToTab, removeTab } = useTabs()
   const { userConfig } = useContext(LaWalletContext)
+  const tabId = query.get('tab')
 
   // Local states
   const [cardStatus, setCardStatus] = useState<LNURLWStatus>(LNURLWStatus.IDLE)
   const [error, setError] = useState<string>()
+  const [showTabSheet, setShowTabSheet] = useState(false)
+  const [newCustomerName, setNewCustomerName] = useState('')
+  const [addedTab, setAddedTab] = useState<ITab | null>(null)
+  const [showTabDetails, setShowTabDetails] = useState(false)
 
   /** Functions */
   const handleBack = useCallback(() => {
@@ -86,6 +104,49 @@ export default function Page() {
           : '/'
     router.replace(target)
   }, [clear, lastCheckoutBack, query, router])
+
+  const handleAddToTab = (name: string, existingId?: string) => {
+    const trimmed = name.trim()
+    if (!trimmed || amount <= 0) return
+
+    const tabItems: ProductQtyData[] =
+      products.length > 0
+        ? products
+        : [
+            {
+              id: 0,
+              category_id: 0,
+              name: 'Caja',
+              description: '',
+              price: { value: amount, currency: 'SAT' },
+              qty: 1
+            }
+          ]
+
+    const tab = addToTab(trimmed, tabItems, amount, existingId)
+    setShowTabSheet(false)
+    setNewCustomerName('')
+    setShowTabDetails(false)
+    setAddedTab(tab)
+  }
+
+  const handleCloseTab = (tab: ITab) => {
+    if (tab.amount <= 0) return
+
+    setAddedTab(null)
+    setAmount(tab.amount)
+    setProducts(tab.items)
+
+    if (tipEnabled) {
+      router.push(`/tip?back=/tab&tab=${tab.id}`)
+      return
+    }
+
+    const order = generateOrderEvent!(tab.amount, tab.items)
+    publishOrderInBackground!(order)
+    setOrderEvent!(order)
+    router.push(`/payment/${order.id}?back=/tab&tab=${tab.id}`)
+  }
 
   const processRegularPayment = useCallback(
     async (response: LNURLResponse) => {
@@ -177,6 +238,24 @@ export default function Page() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isPaid, amount, products, print])
 
+  // Clear the customer's tab once their account is settled
+  useEffect(() => {
+    if (isPaid && tabId) {
+      removeTab(tabId)
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isPaid, tabId])
+
+  // Auto-close the "added to tab" confirmation after 2s (unless details opened)
+  useEffect(() => {
+    if (!addedTab || showTabDetails) {
+      return
+    }
+
+    const timer = setTimeout(() => handleBack(), 2000)
+    return () => clearTimeout(timer)
+  }, [addedTab, showTabDetails, handleBack])
+
   // on card scanStatus change
   useEffect(() => {
     switch (scanStatus) {
@@ -199,6 +278,100 @@ export default function Page() {
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
+
+  if (addedTab) {
+    const totalItems = addedTab.items.reduce((sum, item) => sum + item.qty, 0)
+
+    return (
+      <>
+        <Container size="small">
+          <Divider y={24} />
+          <Flex
+            direction="column"
+            justify="center"
+            align="center"
+            gap={8}
+            flex={1}
+          >
+            <Icon color={theme.colors.primary}>
+              <CheckIcon />
+            </Icon>
+            <Text size="small" color={theme.colors.gray50}>
+              Agregado a la cuenta
+            </Text>
+            <Heading>{addedTab.name}</Heading>
+            <Flex justify="center" align="center" gap={4}>
+              <Heading>{addedTab.amount}</Heading>
+              <Text>SAT</Text>
+            </Flex>
+            <Text size="small" color={theme.colors.gray50}>
+              $
+              {formatToPreference(
+                'ARS',
+                convertCurrency(addedTab.amount, 'SAT', 'ARS')
+              )}{' '}
+              ARS
+            </Text>
+
+            {showTabDetails && (
+              <>
+                <Divider y={8} />
+                <Flex direction="column" gap={4}>
+                  {addedTab.items.map(item => (
+                    <Text key={item.id} size="small">
+                      {item.qty}x {item.name}
+                    </Text>
+                  ))}
+                </Flex>
+                <Text size="small" color={theme.colors.gray50}>
+                  {totalItems} {totalItems === 1 ? 'item' : 'items'}
+                </Text>
+              </>
+            )}
+          </Flex>
+          <Divider y={24} />
+        </Container>
+
+        <Flex>
+          <Container size="small">
+            <Divider y={16} />
+            <Flex gap={8} direction="column">
+              {showTabDetails ? (
+                <>
+                  <Flex>
+                    <Button
+                      variant="bezeled"
+                      onClick={() => handleCloseTab(addedTab)}
+                    >
+                      Cerrar cuenta ({addedTab.amount} SAT)
+                    </Button>
+                  </Flex>
+                  <Flex>
+                    <Button
+                      variant="bezeledGray"
+                      onClick={() => handleBack()}
+                    >
+                      Volver
+                    </Button>
+                  </Flex>
+                </>
+              ) : (
+                <Flex>
+                  <Button
+                    variant="bezeledGray"
+                    onClick={() => setShowTabDetails(true)}
+                  >
+                    Ver detalle
+                  </Button>
+                </Flex>
+              )}
+            </Flex>
+            <Divider y={24} />
+          </Container>
+        </Flex>
+      </>
+    )
+  }
 
   if (orderError && !isPaid) {
     return (
@@ -375,6 +548,16 @@ export default function Page() {
             <Container size="small">
               <Divider y={16} />
               <Flex gap={8} direction="column">
+                {tabEnabled && !tabId && (
+                  <Flex>
+                    <Button
+                      variant="bezeled"
+                      onClick={() => setShowTabSheet(true)}
+                    >
+                      Agregar a tab
+                    </Button>
+                  </Flex>
+                )}
                 <Flex gap={8}>
                   {isAvailable && permission === 'prompt' && (
                     <Button variant="bezeledGray" onClick={() => startRead()}>
@@ -401,6 +584,54 @@ export default function Page() {
           </Flex>
         </>
       )}
+
+      <Sheet
+        isOpen={showTabSheet}
+        onClose={() => {
+          setShowTabSheet(false)
+          setNewCustomerName('')
+        }}
+        title="Agregar a tab"
+      >
+        <Container>
+          <Divider y={8} />
+          <Flex direction="column" gap={8}>
+            <Input
+              value={newCustomerName}
+              onChange={e => setNewCustomerName(e.target.value)}
+              placeholder="Nombre del cliente"
+            />
+            <Flex>
+              <Button
+                color="secondary"
+                variant="bezeled"
+                onClick={() => handleAddToTab(newCustomerName)}
+              >
+                Crear y agregar
+              </Button>
+            </Flex>
+          </Flex>
+          <Divider y={16} />
+          {Object.values(tabs).length > 0 && (
+            <Flex direction="column" gap={8}>
+              <Text size="small" color={theme.colors.gray50}>
+                Clientes
+              </Text>
+              {Object.values(tabs).map(tab => (
+                <Flex key={tab.id}>
+                  <Button
+                    variant="bezeledGray"
+                    onClick={() => handleAddToTab(tab.name, tab.id)}
+                  >
+                    {tab.name}
+                  </Button>
+                </Flex>
+              ))}
+            </Flex>
+          )}
+          <Divider y={16} />
+        </Container>
+      </Sheet>
     </>
   )
 }

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -30,6 +30,10 @@ export default function Page() {
     'tipEnabled',
     false
   )
+  const [tabEnabled, setTabEnabled] = useLocalStorage<boolean>(
+    'tabEnabled',
+    false
+  )
   // Generate random private key
 
   const [, forceUpdate] = useState(0)
@@ -88,6 +92,24 @@ export default function Page() {
               }}
               onChange={e => setTipEnabled(e.target.checked)}
               checked={tipEnabled}
+              type="checkbox"
+            />
+          </Flex>
+
+          <Flex direction="row" align="center" justify="space-between" gap={16}>
+            <Flex direction="column" gap={4}>
+              <Heading as="h5">Tab</Heading>
+              <Text color={theme.colors.gray50} size="small">
+                Llevar cuenta por cliente (tab de bar).
+              </Text>
+            </Flex>
+            <input
+              style={{
+                width: '40px',
+                height: '40px'
+              }}
+              onChange={e => setTabEnabled(e.target.checked)}
+              checked={tabEnabled}
               type="checkbox"
             />
           </Flex>

--- a/src/app/tab/page.tsx
+++ b/src/app/tab/page.tsx
@@ -1,0 +1,177 @@
+'use client'
+
+// React/Next
+import { useMemo, useState } from 'react'
+import { useRouter } from 'next/navigation'
+
+// Third-party
+import { useLocalStorage } from 'react-use-storage'
+
+// Contexts and Hooks
+import { useOrder } from '@/context/Order'
+import { useTabs } from '@/hooks/useTabs'
+import useCurrencyConverter from '@/hooks/useCurrencyConverter'
+
+// Utils
+import { formatToPreference } from '@/lib/formatter'
+
+// Types
+import { ITab } from '@/types/tab'
+
+// Components
+import {
+  Flex,
+  Heading,
+  Text,
+  Divider,
+  Card,
+  Button,
+  Sheet
+} from '@/components/UI'
+import Container from '@/components/Layout/Container'
+import Navbar from '@/components/Layout/Navbar'
+
+export default function TabPage() {
+  const router = useRouter()
+  const { tabs, clearTabs } = useTabs()
+  const { convertCurrency } = useCurrencyConverter()
+  const [tipEnabled] = useLocalStorage<boolean>('tipEnabled', false)
+  const {
+    setAmount,
+    setProducts,
+    setOrderEvent,
+    generateOrderEvent,
+    publishOrderInBackground
+  } = useOrder()
+
+  const [showConfirm, setShowConfirm] = useState(false)
+
+  const openTabs = useMemo(
+    () => Object.values(tabs).sort((a, b) => b.updatedAt - a.updatedAt),
+    [tabs]
+  )
+
+  const handleClearAll = () => {
+    if (openTabs.length === 0) return
+    setShowConfirm(true)
+  }
+
+  const confirmClearAll = () => {
+    clearTabs()
+    setShowConfirm(false)
+  }
+
+  const handlePay = (tab: ITab) => {
+    if (tab.amount <= 0) return
+
+    setAmount(tab.amount)
+    setProducts(tab.items)
+
+    if (tipEnabled) {
+      router.push(`/tip?back=/tab&tab=${tab.id}`)
+      return
+    }
+
+    const order = generateOrderEvent!(tab.amount, tab.items)
+    publishOrderInBackground!(order)
+    setOrderEvent!(order)
+    router.push(`/payment/${order.id}?back=/tab&tab=${tab.id}`)
+  }
+
+  return (
+    <>
+      <Navbar showBackPage={true}>
+        <Heading as="h5">Cerrar cuenta</Heading>
+      </Navbar>
+      <Container size="small">
+        <Divider y={24} />
+        <Flex direction="column" gap={16}>
+          {openTabs.length === 0 ? (
+            <Text size="small">No hay cuentas abiertas.</Text>
+          ) : (
+            <>
+              {openTabs.map(tab => (
+                <Card key={tab.id}>
+                  <button
+                    style={{
+                      all: 'unset',
+                      cursor: 'pointer',
+                      width: '100%'
+                    }}
+                    onClick={() => handlePay(tab)}
+                  >
+                    <Flex direction="column" gap={8}>
+                      <Flex justify="space-between" align="center" gap={8}>
+                        <Heading as="h5">{tab.name}</Heading>
+                        <Flex flex={0}>
+                          <Heading as="h5">{tab.amount}</Heading>
+                          <Text size="small">SAT</Text>
+                        </Flex>
+                      </Flex>
+
+                      {tab.items.length > 0 && (
+                        <Text size="small">
+                          {tab.items
+                            .map(item => `${item.qty}x ${item.name}`)
+                            .join(', ')}
+                        </Text>
+                      )}
+
+                      <Text size="small">
+                        $
+                        {formatToPreference(
+                          'ARS',
+                          convertCurrency(tab.amount, 'SAT', 'ARS')
+                        )}{' '}
+                        ARS
+                      </Text>
+                    </Flex>
+                  </button>
+                </Card>
+              ))}
+
+              <Divider y={8} />
+              <Flex>
+                <Button
+                  variant="bezeled"
+                  color="error"
+                  onClick={handleClearAll}
+                >
+                  Borrar todo
+                </Button>
+              </Flex>
+            </>
+          )}
+        </Flex>
+        <Divider y={24} />
+      </Container>
+
+      <Sheet
+        isOpen={showConfirm}
+        onClose={() => setShowConfirm(false)}
+        title="Borrar cuentas"
+      >
+        <Container>
+          <Divider y={8} />
+          <Text>
+            ¿Seguro que querés borrar todas las cuentas abiertas? Esta acción no
+            se puede deshacer.
+          </Text>
+          <Divider y={16} />
+          <Flex gap={8}>
+            <Button
+              variant="bezeledGray"
+              onClick={() => setShowConfirm(false)}
+            >
+              Cancelar
+            </Button>
+            <Button variant="bezeled" color="error" onClick={confirmClearAll}>
+              Borrar todo
+            </Button>
+          </Flex>
+          <Divider y={16} />
+        </Container>
+      </Sheet>
+    </>
+  )
+}

--- a/src/app/tip/page.tsx
+++ b/src/app/tip/page.tsx
@@ -46,6 +46,7 @@ function TipContent() {
   const { convertCurrency } = useCurrencyConverter()
 
   const backParam = query.get('back')
+  const tabId = query.get('tab')
   const back =
     backParam && backParam !== '/tip'
       ? backParam
@@ -120,13 +121,18 @@ function TipContent() {
       const order = generateOrderEvent!(finalAmount, finalProducts)
       publishOrderInBackground!(order)
       setOrderEvent!(order)
+      const params = new URLSearchParams()
+      if (back) params.set('back', back)
+      if (tabId) params.set('tab', tabId)
+      const queryString = params.toString()
       router.push(
-        `/payment/${order.id}${back ? `?back=${encodeURIComponent(back)}` : ''}`
+        `/payment/${order.id}${queryString ? `?${queryString}` : ''}`
       )
     },
     [
       amount,
       back,
+      tabId,
       generateOrderEvent,
       mainPath,
       publishOrderInBackground,

--- a/src/components/Layout/Navbar/style.tsx
+++ b/src/components/Layout/Navbar/style.tsx
@@ -14,10 +14,22 @@ export const Navbar = styled.div<NavbarProps>`
 `
 
 export const BackButton = styled.button`
-  background-color: transparent;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  width: 40px;
+  height: 40px;
+
+  background-color: ${theme.colors.gray15};
   border: none;
+  border-radius: 50%;
 
   color: ${theme.colors.primary};
 
   cursor: pointer;
+
+  &:hover {
+    opacity: 0.85;
+  }
 `

--- a/src/hooks/useTabs.ts
+++ b/src/hooks/useTabs.ts
@@ -1,0 +1,71 @@
+import { useLocalStorage } from 'react-use-storage'
+
+import { ITab, ITabsCache } from '@/types/tab'
+import { ProductQtyData } from '@/types/product'
+import { mergeProducts } from '@/lib/utils'
+
+interface TabsReturns {
+  tabs: ITabsCache
+  addToTab: (
+    name: string,
+    items: ProductQtyData[],
+    amountSat: number,
+    existingId?: string
+  ) => ITab
+  removeTab: (id: string) => void
+  clearTabs: () => void
+}
+
+const generateTabId = (): string => {
+  if (typeof crypto !== 'undefined' && crypto.randomUUID) {
+    return crypto.randomUUID()
+  }
+  return `${Date.now()}-${Math.random().toString(36).slice(2)}`
+}
+
+export const useTabs = (): TabsReturns => {
+  const [tabs, setTabs] = useLocalStorage<ITabsCache>('tabs', {})
+
+  const addToTab = (
+    name: string,
+    items: ProductQtyData[],
+    amountSat: number,
+    existingId?: string
+  ): ITab => {
+    const now = Date.now()
+    const existing = existingId ? tabs[existingId] : undefined
+
+    if (existing) {
+      const updated: ITab = {
+        ...existing,
+        items: mergeProducts(existing.items, items),
+        amount: existing.amount + amountSat,
+        updatedAt: now
+      }
+      setTabs({ ...tabs, [existing.id]: updated })
+      return updated
+    }
+
+    const id = generateTabId()
+    const tab: ITab = {
+      id,
+      name,
+      items,
+      amount: amountSat,
+      createdAt: now,
+      updatedAt: now
+    }
+    setTabs({ ...tabs, [id]: tab })
+    return tab
+  }
+
+  const removeTab = (id: string) => {
+    const rest = { ...tabs }
+    delete rest[id]
+    setTabs(rest)
+  }
+
+  const clearTabs = () => setTabs({})
+
+  return { tabs, addToTab, removeTab, clearTabs }
+}

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -111,6 +111,25 @@ export const aggregateProducts = (
   return Array.from(productMap.values())
 }
 
+export const mergeProducts = (
+  existing: ProductQtyData[],
+  incoming: ProductQtyData[]
+): ProductQtyData[] => {
+  const productMap = new Map<string, ProductQtyData>()
+
+  ;[...existing, ...incoming].forEach(product => {
+    const key = `${product.id}`
+    const existingProduct = productMap.get(key)
+    if (existingProduct) {
+      existingProduct.qty += product.qty
+    } else {
+      productMap.set(key, { ...product })
+    }
+  })
+
+  return Array.from(productMap.values())
+}
+
 export function isValidUrl(urlString: string): boolean {
   const expression =
     /[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b([-a-zA-Z0-9()@:%_\+.~#?&//=]*)?/gi

--- a/src/types/tab.ts
+++ b/src/types/tab.ts
@@ -1,0 +1,14 @@
+import { ProductQtyData } from './product'
+
+export interface ITab {
+  id: string // generated (crypto.randomUUID())
+  name: string // customer name
+  items: ProductQtyData[] // accumulated items across rounds
+  amount: number // accumulated total in SAT
+  createdAt: number
+  updatedAt: number
+}
+
+export interface ITabsCache {
+  [tabId: string]: ITab
+}


### PR DESCRIPTION
## What

Adds an optional **Tab** feature (bar-style running accounts per customer), toggled from **Settings**. When on, the operator can ring up items and add them to a named customer's tab instead of charging immediately, then close/pay the account later — reusing the existing Lightning payment + print flow.

## Flow

- **Settings** → new **Tab** toggle (persisted as `tabEnabled`).
- **Payment screen** → an **"Agregar a tab"** button below the QR opens a customer picker (create new by name, or pick an existing customer). On add, a confirmation screen appears:
  - Auto-closes after **2s** (returns to the cart).
  - **"Ver detalle"** cancels the auto-close and shows the order list, item count, total, and **"Cerrar cuenta"** (pay the whole tab → QR).
- **Home** → **"Cerrar cuenta"** card (only when enabled) lists open tabs with items + totals (SAT/ARS). Tapping a customer charges the tab through the normal payment flow (honors the Tip screen if enabled); the tab is cleared once the payment settles. **"Borrar todo"** wipes all tabs behind an in-app confirmation sheet.

## Implementation

- `useTabs` hook + `mergeProducts` util persist and accumulate tabs in `localStorage` (`tabs`); new `ITab`/`ITabsCache` types.
- Paying a tab reuses `generateOrderEvent` → `/payment` → existing auto-print; the `tab` id is threaded cart → tip → payment so the right tab clears on settlement.

## UI tweaks (same change set)

- Navbar **back button** is now a circular button.
- **Settings** moved from a home card to a **top-right circular icon button** (reusing the existing `Top` component).

## Verification

- `tsc --noEmit` and ESLint clean on all touched files.
- Walked the full flow in a local dev preview: toggle on → add items → add to a customer → confirmation (2s auto-close + details) → home list with totals → close tab routes to the QR with the `tab` param. The settlement-triggered tab clear + receipt print fire only on a real Lightning payment (Android print bridge), so that leg is covered by code review.

> Note: the receipt is unchanged (items + totals, no customer name), per product decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)