### PR TITLE
fix: new orders get a fresh invoice + no duplicate card-tap callbacks

### DIFF
--- a/src/app/payment/[orderId]/page.tsx
+++ b/src/app/payment/[orderId]/page.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 // React/Next
-import { useCallback, useContext, useEffect, useState } from 'react'
+import { useCallback, useContext, useEffect, useRef, useState } from 'react'
 import { useParams, useRouter, useSearchParams } from 'next/navigation'
 import { useLocalStorage } from 'react-use-storage'
 
@@ -167,15 +167,28 @@ export default function Page() {
     [invoice]
   )
 
+  // Guard against processing the same invoice more than once. A single physical
+  // tap can trigger startRead repeatedly (the effect re-firing, the manual
+  // button, or the NFC layer re-reading a card left on the reader), which would
+  // POST the same SUN p/c to /scan/cb twice — the second hit fails with
+  // "counter value too old". Keying on `invoice` lets a genuinely new order
+  // (new invoice) read again, while a failed attempt can be retried.
+  const processedInvoiceRef = useRef<string | undefined>(undefined)
+
   const startRead = useCallback(async () => {
+    if (isPaid || !invoice || processedInvoiceRef.current === invoice) return
+    processedInvoiceRef.current = invoice
     try {
       const { lnurlResponse } = await scan(ScanAction.PAY_REQUEST)
       await processRegularPayment(lnurlResponse)
+      // Paid: stop the reader so a duplicate read can't re-POST the same tap.
+      stop()
     } catch (e) {
       setCardStatus(LNURLWStatus.ERROR)
       setError((e as Error).message)
+      processedInvoiceRef.current = undefined // allow a retry for this invoice
     }
-  }, [processRegularPayment, scan])
+  }, [invoice, isPaid, processRegularPayment, scan, stop])
 
   /** useEffects */
   // Search for orderIdFromURL
@@ -347,10 +360,7 @@ export default function Page() {
                     </Button>
                   </Flex>
                   <Flex>
-                    <Button
-                      variant="bezeledGray"
-                      onClick={() => handleBack()}
-                    >
+                    <Button variant="bezeledGray" onClick={() => handleBack()}>
                       Volver
                     </Button>
                   </Flex>

--- a/src/context/Order.tsx
+++ b/src/context/Order.tsx
@@ -207,76 +207,87 @@ export const OrderProvider = ({ children }: IOrderProviderProps) => {
     [setPaymentsCache]
   )
 
-  const generateOrderEvent = useCallback((
-    customAmount?: number,
-    customProducts?: ProductQtyData[]
-  ): Event => {
-    const orderAmount = customAmount ?? amount
-    const orderProducts = customProducts ?? products
-    const unsignedEvent: UnsignedEvent = {
-      kind: 1,
-      content: '',
-      pubkey: localPublicKey!,
-      created_at: Math.round(Date.now() / 1000),
-      tags: [
-        ['relays', ...relays!],
-        ['p', localPublicKey],
-        ['t', 'order'],
-        [
-          'description',
-          JSON.stringify({
-            memo,
-            amount: orderAmount
-          })
-        ],
-        ['products', JSON.stringify(orderProducts)]
-      ] as string[][]
-    }
+  const generateOrderEvent = useCallback(
+    (customAmount?: number, customProducts?: ProductQtyData[]): Event => {
+      const orderAmount = customAmount ?? amount
+      const orderProducts = customProducts ?? products
+      // A per-checkout nonce guarantees a UNIQUE event id even when the
+      // amount/products/memo and the (second-resolution) created_at are identical
+      // — otherwise two orders collide on the same id and the payment page reuses
+      // the previous order's invoice (the id-keyed invoice effect never re-fires).
+      const nonce =
+        globalThis.crypto?.randomUUID?.() ??
+        `${Date.now()}-${Math.random().toString(36).slice(2)}`
+      const unsignedEvent: UnsignedEvent = {
+        kind: 1,
+        content: '',
+        pubkey: localPublicKey!,
+        created_at: Math.round(Date.now() / 1000),
+        tags: [
+          ['relays', ...relays!],
+          ['p', localPublicKey],
+          ['t', 'order'],
+          ['nonce', nonce],
+          [
+            'description',
+            JSON.stringify({
+              memo,
+              amount: orderAmount
+            })
+          ],
+          ['products', JSON.stringify(orderProducts)]
+        ] as string[][]
+      }
 
-    const event = finalizeEvent(unsignedEvent, hexToBytes(localPrivateKey!))
+      const event = finalizeEvent(unsignedEvent, hexToBytes(localPrivateKey!))
 
-    // Saving current payments status
-    const payment: IPayment = {
-      amount: orderAmount,
-      event: event!,
-      id: event!.id,
-      isPaid,
-      lud06: lud06!,
-      isPrinted: isPrinted,
-      items: orderProducts,
-      createdAt: event.created_at,
-      nostrPublishStatus: 'pending',
-      nostrRelayUrls: [],
-      zapReceiptStatus: 'pending',
-      zapReceiptRelayUrls: []
-    }
+      // Saving current payments status
+      const payment: IPayment = {
+        amount: orderAmount,
+        event: event!,
+        id: event!.id,
+        // A freshly generated order is always unpaid/unprinted — never inherit
+        // the current (possibly stale) context flags.
+        isPaid: false,
+        lud06: lud06!,
+        isPrinted: false,
+        items: orderProducts,
+        createdAt: event.created_at,
+        nostrPublishStatus: 'pending',
+        nostrRelayUrls: [],
+        zapReceiptStatus: 'pending',
+        zapReceiptRelayUrls: []
+      }
 
-    const updatedCache = { ...paymentsCacheRef.current, [payment.id]: payment }
-    paymentsCacheRef.current = updatedCache
-    setPaymentsCache(updatedCache)
-    setAmount(orderAmount)
-    setIsPaid(false)
-    isPaidRef.current = false
-    setIsPrinted(false)
-    setCurrentInvoice(undefined)
-    setLUD21(undefined)
-    setError(undefined)
-    setOrderEvent(event)
-    setOrderId(payment.id)
+      const updatedCache = {
+        ...paymentsCacheRef.current,
+        [payment.id]: payment
+      }
+      paymentsCacheRef.current = updatedCache
+      setPaymentsCache(updatedCache)
+      setAmount(orderAmount)
+      setIsPaid(false)
+      isPaidRef.current = false
+      setIsPrinted(false)
+      setCurrentInvoice(undefined)
+      setLUD21(undefined)
+      setError(undefined)
+      setOrderEvent(event)
+      setOrderId(payment.id)
 
-    return event
-  }, [
-    localPublicKey,
-    relays,
-    memo,
-    amount,
-    products,
-    localPrivateKey,
-    isPaid,
-    lud06,
-    isPrinted,
-    setPaymentsCache
-  ])
+      return event
+    },
+    [
+      localPublicKey,
+      relays,
+      memo,
+      amount,
+      products,
+      localPrivateKey,
+      lud06,
+      setPaymentsCache
+    ]
+  )
 
   const publishOrderInBackground = useCallback(
     (order: Event) => {
@@ -428,13 +439,14 @@ export const OrderProvider = ({ children }: IOrderProviderProps) => {
       }
 
       zapReceiptRelaysRef.current[zapReceiptId] = receiptRelayUrls
-      orderId && updateCachedPayment(orderId, {
-        zapReceiptStatus:
-          receiptRelayUrls.size >= REQUIRED_NOSTR_RELAY_COUNT
-            ? 'confirmed'
-            : 'pending',
-        zapReceiptRelayUrls: Array.from(receiptRelayUrls)
-      })
+      orderId &&
+        updateCachedPayment(orderId, {
+          zapReceiptStatus:
+            receiptRelayUrls.size >= REQUIRED_NOSTR_RELAY_COUNT
+              ? 'confirmed'
+              : 'pending',
+          zapReceiptRelayUrls: Array.from(receiptRelayUrls)
+        })
 
       if (receiptRelayUrls.size < REQUIRED_NOSTR_RELAY_COUNT) {
         console.info(
@@ -528,7 +540,7 @@ export const OrderProvider = ({ children }: IOrderProviderProps) => {
     setCheckEmergencyEvent(false)
     setSubZap(undefined)
     zapReceiptRelaysRef.current = {}
-    invoiceRequestIdRef.current++  // Invalidate any in-flight invoice requests
+    invoiceRequestIdRef.current++ // Invalidate any in-flight invoice requests
   }, [])
 
   /** useEffects */
@@ -547,7 +559,10 @@ export const OrderProvider = ({ children }: IOrderProviderProps) => {
     const updatedIsPaid = order.isPaid || isPaid
     const updatedIsPrinted = order.isPrinted || isPrinted
     // Only update if values actually changed
-    if (updatedIsPaid !== order.isPaid || updatedIsPrinted !== order.isPrinted) {
+    if (
+      updatedIsPaid !== order.isPaid ||
+      updatedIsPrinted !== order.isPrinted
+    ) {
       setPaymentsCache({
         ...paymentsCache,
         [orderId]: {
@@ -613,7 +628,9 @@ export const OrderProvider = ({ children }: IOrderProviderProps) => {
       .then(_invoice => {
         // Only update state if this is still the current request
         if (requestId !== invoiceRequestIdRef.current) {
-          console.warn('Ignoring stale invoice response (superseded by newer request)')
+          console.warn(
+            'Ignoring stale invoice response (superseded by newer request)'
+          )
           return
         }
         setLUD21(_invoice.verify)
@@ -628,13 +645,7 @@ export const OrderProvider = ({ children }: IOrderProviderProps) => {
         setError(`Couldn't generate invoice. ${e.cause ?? e.message}`)
       })
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [
-    amount,
-    currentInvoice,
-    orderId,
-    updateCachedPayment,
-    zapEmitterPubKey
-  ])
+  }, [amount, currentInvoice, orderId, updateCachedPayment, zapEmitterPubKey])
 
   const handleResubscription = useCallback(
     (relay: NDKRelay) => {


### PR DESCRIPTION
## Problema

Al cobrar con tarjeta, a veces el pago daba **`400 counter value too old`** y/o **`this invoice has already been paid`**. Diagnóstico (logs del backend + lectura del código): el POS **reusaba la misma invoice entre órdenes** y **golpeaba `/scan/cb` dos veces por tap**.

## Causas raíz y fixes

### 1. `Order.tsx` — el `orderId` (id del evento nostr) era determinístico
`generateOrderEvent` derivaba el id de `(amount, products, memo)` + `created_at` en **segundos**, así que dos órdenes con el mismo contenido podían **colisionar en el mismo id**. Como el efecto que genera la invoice está **keyed en `orderId`**, una orden colisionada **no regeneraba su invoice** (y la página de pago reusaba la anterior) → `already been paid`.

- Se agrega un **`nonce` único por checkout** → el id del evento es siempre distinto.
- La orden recién generada se cachea con **`isPaid: false` / `isPrinted: false`** (no hereda flags viejas).

> Los tags se parsean por nombre en `lib/utils.ts`, así que agregar `nonce` es seguro.

### 2. `payment/[orderId]/page.tsx` — un tap se procesaba más de una vez
Un solo tap podía disparar `startRead` varias veces (el `useEffect` re-disparándose, el botón manual, o el lector NFC releyendo la tarjeta apoyada) → **dos POST a `/scan/cb` con el mismo `p/c`** → el segundo cae en el anti-replay del servidor (`counter value too old`).

- `startRead` ahora tiene **guarda de reentrada por `invoice`** (una orden nueva sí puede leer; un intento fallido se puede reintentar).
- Tras un pago OK se llama **`stop()`** para cortar el lector y que una lectura repetida no re-postee el tap.

## Resultado
- Cada orden nueva → **id único** → invoice nueva + `isPaid` reseteado.
- Un tap → **un solo** `/scan/cb`. Se acaban el `already been paid` entre órdenes y el `counter value too old` por doble-fetch.

## Notas para el reviewer
- Rebasado sobre `main` actual (incluye #26/#27); los fixes se re-aplicaron sobre el `generateOrderEvent`/`startRead` refactorizados.
- `npx tsc --noEmit` limpio en `src/` (los errores de `.next/types` son artefactos viejos preexistentes).
- `next lint` limpio en los archivos tocados.
- Sin cambios de dependencias ni de API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
